### PR TITLE
添加临时步骤并更新初始化脚本

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Pull Requests Merge
         run: echo "pull requests merge"
 
+      - name: Tmp steps
+        run: ls -al /
+
   build-ubuntu:
     runs-on: ubuntu-latest
     container:
@@ -27,7 +30,9 @@ jobs:
 
     steps:
       - name: Init Ubuntu for Github Action
-        run: ls -l /
+        run: |
+          ln -s /home/runner/work /__w
+          ln -s /home/runner/work/_temp /__t
 
       - name: Echo Github Work Space
         run: |
@@ -61,7 +66,9 @@ jobs:
 
     steps:
       - name: Init Redhat UBI 9 for Github Action
-        run: ls -l /
+        run: |
+          ln -s /home/runner/work /__w
+          ln -s /home/runner/work/_temp /__t
 
       - name: Echo Github Work Space
         run: |


### PR DESCRIPTION
在 `go-pr-merge` 工作流中添加了一个临时步骤来列出根目录内容，并更新了 Ubuntu 和 Redhat UBI 9 的初始化脚本以创建必要的符号链接。