### PR TITLE
移除临时步骤并更新构建目录列表命令

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -19,9 +19,6 @@ jobs:
       - name: Pull Requests Merge
         run: echo "pull requests merge"
 
-      - name: Tmp steps
-        run: ls -al /
-
   build-ubuntu:
     runs-on: ubuntu-latest
     container:
@@ -50,7 +47,10 @@ jobs:
         run: go build -o "${{ github.workspace }}/${{ env.OUTPUT_UBUNTU_NAME }}" -trimpath -ldflags="-s -w" github.com/SongZihuan/TestGithubAction
 
       - name: List build directory
-        run: ls -l "${{ github.workspace }}"
+        run: |
+          ls -l "${{ github.workspace }}" || 0
+          ls -l /__w  || 0
+          ls -l /__w/TestGithubAction/TestGithubAction || 0
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
删除了名为“Tmp steps”的临时步骤，并修改了构建目录的列表命令，使其即使在某些路径不存在时也能继续执行。这样可以更全面地查看工作空间及关联目录的内容。