### PR TITLE
添加临时任务并更新输出和文件路径

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -22,6 +22,12 @@ env:
   CHANGE_LOG_DEB_BRANCH: changelog-deb
 
 jobs:
+  tmp:
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: "echo 'Ref: ${{ github.event.pull_request.head.ref }}'"
+
   merge:
 #    if: github.event.pull_request.merged == true # 仅当PR被合并时触发
     if: github.event.pull_request.head.ref != 'changelog-deb'
@@ -442,6 +448,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
+    outputs:
+      PACKAGE_NAME: ${{ env.PACKAGE_NAME }}
+      VERSION: ${{ steps.before-package.outputs.VERSION }}
+      ARCHITECTURE: ${{ steps.package.outputs.Architecture }}
+
   upload_package_deb:
     runs-on: ubuntu-latest
     needs:
@@ -457,14 +468,14 @@ jobs:
 
       - name: Get MD5
         run: |
-          echo "$(md5sum ${{ github.workspace }}/${{ steps.package.outputs.Architecture }}.deb | awk '{print $1}')" > ${{ github.workspace }}/${{ steps.package.outputs.Architecture }}.deb.md5
+          echo "$(md5sum ${{ github.workspace }}/${{ needs.build_deb.outputs.PACKAGE_NAME }}_${{ needs.build_deb.outputs.VERSION }}_${{ needs.build_deb.outputs.ARCHITECTURE }}.deb | awk '{print $1}')" > ${{ github.workspace }}/${{ needs.build_deb.outputs.PACKAGE_NAME }}_${{ needs.build_deb.outputs.VERSION }}_${{ needs.build_deb.outputs.ARCHITECTURE }}.deb.md5
           
       - name: Upload Release Asset
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ needs.create_release.outputs.tag }}
           files: |
-            ${{ github.workspace }}/${{ steps.package.outputs.Architecture }}.deb
-            ${{ github.workspace }}/${{ steps.package.outputs.Architecture }}.deb.md5
+            ${{ github.workspace }}/${{ needs.build_deb.outputs.PACKAGE_NAME }}_${{ needs.build_deb.outputs.VERSION }}_${{ needs.build_deb.outputs.ARCHITECTURE }}.deb
+            ${{ github.workspace }}/${{ needs.build_deb.outputs.PACKAGE_NAME }}_${{ needs.build_deb.outputs.VERSION }}_${{ needs.build_deb.outputs.ARCHITECTURE }}.deb.md5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # 自动提供的 GitHub Token


### PR DESCRIPTION
在工作流中新增了一个名为 `tmp` 的临时任务，用于打印PR的引用。同时，修改了 `upload_package_deb` 任务中的文件路径以使用新的输出变量，并更新了获取MD5值的步骤以匹配新的文件命名格式。