### PR TITLE
更新依赖的工作流触发条件

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -52,7 +52,7 @@ jobs:
       volumes:
         - /home/runner/work:/home/runner/work
         - /home/runner/work:/__w
-    needs: merge
+    needs: ready
 
     steps:
       - name: Checkout code
@@ -84,7 +84,7 @@ jobs:
       volumes:
         - /home/runner/work:/home/runner/work
         - /home/runner/work:/__w
-    needs: merge
+    needs: ready
 
     steps:
       - name: Checkout code
@@ -203,7 +203,7 @@ jobs:
   build_deb:
     runs-on: ubuntu-latest
     needs:
-      - merge
+      - ready
       - create_release
 
     env:


### PR DESCRIPTION
将工作流中的触发条件从 `merge` 更新为 `ready`，以确保在代码准备好时才执行后续步骤。这样可以更准确地控制构建和测试的时机。