### PR TITLE
移除dpkg-buildpackage中的-us和-uc选项

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -382,7 +382,7 @@ jobs:
         run: |
           cat ${{ github.workspace }}/debian/rules
           echo "dh: $(which dh)"
-          DEB_BUILD_OPTIONS="parallel=4 nocheck" dpkg-buildpackage -us -uc -b -k${{ secrets.GPG_KEY_ID }}
+          DEB_BUILD_OPTIONS="parallel=4 nocheck" dpkg-buildpackage -k${{ secrets.GPG_KEY_ID }}
           echo "Architecture=$(cat ${{ env.FILE_ARCHITECTURE }})" >> $GITHUB_OUTPUT
 
       - name: List directory after package


### PR DESCRIPTION
在构建deb包时，移除了不必要的-us和-uc选项，简化了命令。这不会影响构建过程，但使配置更加简洁。