### PR TITLE
移除不必要的 `echo` 命令

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -388,7 +388,6 @@ jobs:
         id: package
         run: |
           cat ${{ github.workspace }}/debian/rules
-          echo "dh: $(which dh)"
           DEB_BUILD_OPTIONS="parallel=4 nocheck" dpkg-buildpackage -k ${{ secrets.GPG_KEY_ID }}
           echo "Architecture=$(cat ${{ env.FILE_ARCHITECTURE }})" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
在 `go-pr-merge.yml` 文件中，删除了用于显示 `dh` 命令路径的 `echo` 语句，简化构建过程。