### PR TITLE
更新 GPG 配置和构建命令

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -246,8 +246,8 @@ jobs:
       
           # 配置 gpg-agent.conf
           echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
-      
-          unset GPG_TTY
+          
+          echo "export GPG_TTY=''" >> $GITHUB_ENV
       
           # 重新加载 gpg-agent
           echo RELOADAGENT | gpg-connect-agent
@@ -389,7 +389,7 @@ jobs:
         id: package
         run: |
           cat ${{ github.workspace }}/debian/rules
-          DEB_BUILD_OPTIONS="parallel=4 nocheck" dpkg-buildpackage --sign-key=${{ secrets.GPG_KEY_ID }}
+          echo "${{ secrets.GPG_PASSPHRASE }}" | DEBSIGN_OPTS="--passphrase-fd 0 --pinentry-mode loopback --batch --yes" DEB_BUILD_OPTIONS="parallel=4 nocheck" dpkg-buildpackage --sign-key="${{ secrets.GPG_KEY_ID }}"
           echo "Architecture=$(cat ${{ env.FILE_ARCHITECTURE }})" >> $GITHUB_OUTPUT
 
       - name: List directory after package


### PR DESCRIPTION
修改了 GPG 的配置方式，通过设置 `GPG_TTY` 环境变量为空字符串来解决密钥签名问题。同时，在执行 dpkg-buildpackage 时增加了对 GPG 密码的处理选项，确保构建过程顺利进行。