### PR TITLE
更新 dpkg-buildpackage 命令以快速签名密钥

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -389,7 +389,7 @@ jobs:
         id: package
         run: |
           cat ${{ github.workspace }}/debian/rules
-          echo "${{ secrets.GPG_PASSPHRASE }}" | DEBSIGN_OPTS="--passphrase-fd 0 --pinentry-mode loopback --batch --yes" DEB_BUILD_OPTIONS="parallel=4 nocheck" dpkg-buildpackage --sign-key="${{ secrets.GPG_KEY_ID }}"
+          echo "${{ secrets.GPG_PASSPHRASE }}" | DEB_BUILD_OPTIONS="parallel=4 nocheck" dpkg-buildpackage --sign-key="${{ secrets.GPG_KEY_ID }}" --sign-command="gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback  --quick-sign-key ${{ secrets.GPG_KEY_ID }}"
           echo "Architecture=$(cat ${{ env.FILE_ARCHITECTURE }})" >> $GITHUB_OUTPUT
 
       - name: List directory after package


### PR DESCRIPTION
在 `dpkg-buildpackage` 命令中添加了 `--quick-sign-key` 选项，以便更快地进行密钥签名。这将提高构建过程的效率。