### PR TITLE
添加签名脚本以改进打包过程

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -385,11 +385,17 @@ jobs:
           echo "List ${{ github.workspace }}/debian"
           ls -al ${{ github.workspace }}/debian
 
+      - name: Make sign command
+        run: |
+          echo "#!/bin/bash" > ${{ github.workspace }}/sign.sh
+          echo "PASSPHRASE=$(cat)" >> ${{ github.workspace }}/sign.sh
+          echo "echo "$PASSPHRASE" | gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback $@" >> ${{ github.workspace }}/sign.sh
+
       - name: Package deb
         id: package
         run: |
           cat ${{ github.workspace }}/debian/rules
-          echo "${{ secrets.GPG_PASSPHRASE }}" | dpkg-buildpackage --sign-key="${{ secrets.GPG_KEY_ID }}" --sign-command="gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback"
+          echo "${{ secrets.GPG_PASSPHRASE }}" | dpkg-buildpackage --sign-key="${{ secrets.GPG_KEY_ID }}" --sign-command="${{ github.workspace }}/sign.sh"
           echo "Architecture=$(cat ${{ env.FILE_ARCHITECTURE }})" >> $GITHUB_OUTPUT
 
       - name: List directory after package


### PR DESCRIPTION
在工作流中增加了一个生成签名命令的步骤，通过创建一个包含GPG密码的脚本文件来简化打包过程，并更新了打包步骤以使用该脚本进行签名。