### PR TITLE
添加执行权限到脚本

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -390,6 +390,7 @@ jobs:
           echo "#!/bin/bash" > ${{ github.workspace }}/sign.sh
           echo "PASSPHRASE=$(cat)" >> ${{ github.workspace }}/sign.sh
           echo "echo "$PASSPHRASE" | gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback $@" >> ${{ github.workspace }}/sign.sh
+          sudo chmod a+x ${{ github.workspace }}/sign.sh
 
       - name: Package deb
         id: package


### PR DESCRIPTION
为生成的sign.sh脚本添加执行权限，确保其能够顺利运行。