### PR TITLE
更新 GPG_TTY 配置并简化签名命令

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -247,7 +247,7 @@ jobs:
           # 配置 gpg-agent.conf
           echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
           
-          echo "export GPG_TTY=''" >> $GITHUB_ENV
+          echo "export GPG_TTY=/dev/null" >> $GITHUB_ENV
       
           # 重新加载 gpg-agent
           echo RELOADAGENT | gpg-connect-agent
@@ -385,18 +385,11 @@ jobs:
           echo "List ${{ github.workspace }}/debian"
           ls -al ${{ github.workspace }}/debian
 
-      - name: Make sign command
-        run: |
-          echo "#!/bin/bash" > ${{ github.workspace }}/sign.sh
-          echo "PASSPHRASE=$(cat)" >> ${{ github.workspace }}/sign.sh
-          echo "echo "$PASSPHRASE" | gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback $@" >> ${{ github.workspace }}/sign.sh
-          sudo chmod a+x ${{ github.workspace }}/sign.sh
-
       - name: Package deb
         id: package
         run: |
           cat ${{ github.workspace }}/debian/rules
-          echo "${{ secrets.GPG_PASSPHRASE }}" | dpkg-buildpackage --sign-key="${{ secrets.GPG_KEY_ID }}" --sign-command="${{ github.workspace }}/sign.sh"
+          echo "${{ secrets.GPG_PASSPHRASE }}" | dpkg-buildpackage --sign-key="${{ secrets.GPG_KEY_ID }}"
           echo "Architecture=$(cat ${{ env.FILE_ARCHITECTURE }})" >> $GITHUB_OUTPUT
 
       - name: List directory after package


### PR DESCRIPTION
将 GPG_TTY 设置为 /dev/null，并移除了自定义的 sign.sh 脚本，直接使用 dpkg-buildpackage 进行签名，简化了工作流程。