### PR TITLE
更新 GPG 环境变量配置

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -247,8 +247,6 @@ jobs:
           # 配置 gpg-agent.conf
           echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
           
-          echo "export GPG_TTY=/dev/null" >> $GITHUB_ENV
-      
           # 重新加载 gpg-agent
           echo RELOADAGENT | gpg-connect-agent
 
@@ -259,7 +257,7 @@ jobs:
 
       - name: Test GPG signing
         run: |
-          echo "${{ secrets.GPG_PASSPHRASE }}" | gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback --quick-sign-key ${{ secrets.GPG_KEY_ID }}
+          echo "${{ secrets.GPG_PASSPHRASE }}" | GPG_TTY='/dev/null' gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback --quick-sign-key ${{ secrets.GPG_KEY_ID }}
           echo "GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}"
 
       - name: Checkout code
@@ -389,7 +387,7 @@ jobs:
         id: package
         run: |
           cat ${{ github.workspace }}/debian/rules
-          echo "${{ secrets.GPG_PASSPHRASE }}" | dpkg-buildpackage --sign-key="${{ secrets.GPG_KEY_ID }}"
+          echo "${{ secrets.GPG_PASSPHRASE }}" | GPG_TTY='/dev/stdin' dpkg-buildpackage --sign-key="${{ secrets.GPG_KEY_ID }}"
           echo "Architecture=$(cat ${{ env.FILE_ARCHITECTURE }})" >> $GITHUB_OUTPUT
 
       - name: List directory after package


### PR DESCRIPTION
移除了不必要的 GPG_TTY 环境变量设置，并直接在命令中指定了 GPG_TTY 的值，以确保 GPG 操作的正确执行。这样可以避免环境变量配置不一致导致的问题。