### PR TITLE
更新依赖安装命令

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -227,13 +227,14 @@ jobs:
     steps:
       - name: Set up dependencies
         run: |
-          sudo apt-get update -y
-          sudo apt-get install -y build-essential
-          sudo apt-get install -y dpkg-dev
-          sudo apt-get install -y devscripts debhelper
-          sudo apt-get install -y debhelper
-          sudo apt-get install -y fakeroot
-          sudo apt-get install -y gnupg
+          sudo apt update -y
+          sudo apt install -y build-essential
+          sudo apt install -y dpkg-dev
+          sudo apt install -y devscripts debhelper
+          sudo apt install -y debhelper
+          sudo apt install -y dpkg-sig
+          sudo apt install -y fakeroot
+          sudo apt install -y gnupg
 
       # 配置 GPG 环境
       - name: Configure GPG


### PR DESCRIPTION
将依赖安装命令从 `apt-get` 更新为 `apt`，并添加 `dpkg-sig` 依赖。