### PR TITLE
移除重复的 `debhelper` 安装命令

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -230,7 +230,7 @@ jobs:
           sudo apt update -y
           sudo apt install -y build-essential
           sudo apt install -y dpkg-dev
-          sudo apt install -y devscripts debhelper
+          sudo apt install -y devscripts
           sudo apt install -y debhelper
           sudo apt install -y dpkg-sig
           sudo apt install -y fakeroot


### PR DESCRIPTION
在安装依赖的步骤中，删除了重复的 `debhelper` 安装命令，以避免冗余。这样可以简化 CI/CD 流程并减少构建时间。