### PR TITLE
更新 GitHub Actions 工作流以包含 GPG 密钥

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -179,22 +179,31 @@ jobs:
       - name: Push tag to github
         run: git push origin "${{ steps.tag_version.outputs.tag }}"
 
+      - name: Write gpg public key
+        run: |
+          echo "${{ secrets.GPG_PUBLIC_KEY }}" > ${{ github.workspace }}/${{ needs.build_deb.outputs.PACKAGE_NAME }}_GPG_PUBLIC.asc
+
+      - name: Write gpg key id
+        run: |
+          echo "${{ secrets.GPG_KEY_ID }}" > ${{ github.workspace }}/${{ secrets.GPG_KEY_ID }}.gpg.key.id
+
       - name: Create github release
         id: create_release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "${{ github.workspace }}/${{ env.OUTPUT_UBUNTU_NAME }},${{ github.workspace }}/${{ env.OUTPUT_REHL_NAME }}"
+          artifacts: "${{ github.workspace }}/${{ needs.build_deb.outputs.PACKAGE_NAME }}_gpg_public.asc,${{ github.workspace }}/${{ secrets.GPG_KEY_ID }}.gpg.key.id${{ github.workspace }}/${{ env.OUTPUT_UBUNTU_NAME }},${{ github.workspace }}/${{ env.OUTPUT_REHL_NAME }}"
           artifactErrorsFailBuild: true
           allowUpdates: false
           body: |
-            新版本 ${{ steps.tag_version.outputs.tag }} 发布啦！
-            快来体验吧！
+            新版本 ${{ steps.tag_version.outputs.tag }} 发布啦，快来体验吧！
+            GPG Key: ${{ secrets.GPG_KEY_ID }} （可从服务器服务器下载公钥）。
           generateReleaseNotes: true
           makeLatest: "legacy"
           tag: "${{ steps.tag_version.outputs.tag }} "
 
       - name: Output the URL of the new release
         run: echo "The release is available at ${{ steps.create_release.outputs.html_url }}"
+
     outputs:
       tag: "${{ steps.tag_version.outputs.tag }}"
       release: "${{ steps.create_release.outputs.html_url }}"
@@ -552,19 +561,11 @@ jobs:
         run: |
           echo "$(sha256sum ${{ github.workspace }}/${{ needs.build_deb.outputs.PACKAGE_NAME }}_${{ needs.build_deb.outputs.VERSION }}_${{ needs.build_deb.outputs.ARCHITECTURE }}.deb | awk '{print $1}')" > ${{ github.workspace }}/${{ needs.build_deb.outputs.PACKAGE_NAME }}_${{ needs.build_deb.outputs.VERSION }}_${{ needs.build_deb.outputs.ARCHITECTURE }}.deb.sha256
 
-      - name: Write public key
-        run: |
-          echo "${{ secrets.GPG_PUBLIC_KEY }}" > ${{ github.workspace }}/${{ needs.build_deb.outputs.PACKAGE_NAME }}_GPG_PUBLIC.asc
-
       - name: Upload release asset
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ needs.create_release.outputs.tag }}
           files: |
-            ${{ github.workspace }}/${{ needs.build_deb.outputs.PACKAGE_NAME }}_GPG_PUBLIC.asc
-            ${{ github.workspace }}/README.md
-            ${{ github.workspace }}/LICENSE
-            
             ${{ github.workspace }}/${{ needs.build_deb.outputs.PACKAGE_NAME }}_${{ needs.build_deb.outputs.VERSION }}_${{ needs.build_deb.outputs.ARCHITECTURE }}.deb
             ${{ github.workspace }}/${{ needs.build_deb.outputs.PACKAGE_NAME }}_${{ needs.build_deb.outputs.VERSION }}_${{ needs.build_deb.outputs.ARCHITECTURE }}.changes
             ${{ github.workspace }}/${{ needs.build_deb.outputs.PACKAGE_NAME }}_${{ needs.build_deb.outputs.VERSION }}_${{ needs.build_deb.outputs.ARCHITECTURE }}.deb.sig


### PR DESCRIPTION
在 GitHub Actions 工作流中添加了写入 GPG 公钥和密钥 ID 的步骤，并更新了创建 GitHub 发布时的 artifact 列表，以便包含这些密钥文件。同时简化了发布说明，移除了不必要的上传文件步骤。