### PR TITLE
修正发布信息文件写入方式

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -189,12 +189,14 @@ jobs:
 
       - name: Make release body
         run: |
-          echo "## 新版本 ${{ steps.tag_version.outputs.tag }} 正式发布 🚀🚀🚀" > ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
+          touch ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
+          
+          echo "## 新版本 ${{ steps.tag_version.outputs.tag }} 正式发布 🚀🚀🚀" >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
           echo "" >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
           echo "欢迎大家前来体验使用！" >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
           echo "" >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
           
-            echo "### GPG说明" > ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
+            echo "### GPG说明" >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
             echo "" >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
             
               echo "#### Linux上" >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
@@ -223,7 +225,7 @@ jobs:
               echo "" >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
               echo "大部分操作的原来和Linux是相同的。`GPG` 方面的操作可以借助 `Kleopatra`。" >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
         
-            echo "### 版本说明 [#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})" > ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
+            echo "### 版本说明 [#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})" >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
             echo "" >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
             echo "${{ github.event.pull_request.body }}" >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
 


### PR DESCRIPTION
将发布信息文件的写入方式从覆盖改为追加，确保所有内容能够完整地写入到文件中。这样可以避免之前每次写入时内容被覆盖的问题。