### PR TITLE
更新版本号提取方式

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -264,7 +264,7 @@ jobs:
 
     outputs:
       tag: "${{ steps.tag_version.outputs.tag }}"
-      version: $(echo "${{ steps.tag_version.outputs.tag }}" | sed 's/^v//')
+      version: "${{ steps.tag_version.outputs.version }}"
       release: "${{ steps.create_release.outputs.url }}"
       upload_url: "${{ steps.create_release.outputs.upload_url }}"
 


### PR DESCRIPTION
将版本号的提取方式从使用 `sed` 命令改为直接使用步骤输出的版本号，简化了流程并提高了可读性。