### PR TITLE
修复文件校验和命名错误

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -622,7 +622,7 @@ jobs:
 
       - name: Get file sha256
         run: |
-          echo "$(sha256sum ${{ github.workspace }}/${{ env.PACKAGE_NAME }}_${{ needs.create_release.outputs.version }}_${{ needs.build_deb.outputs.architecture }}.deb | awk '{print $1}')" > ${{ github.workspace }}/${{ env.PACKAGE_NAME }}_${{ needs.create_release.outputs.version }}_${{ needs.create_release.outputs.architecture }}.deb.sha256
+          echo "$(sha256sum ${{ github.workspace }}/${{ env.PACKAGE_NAME }}_${{ needs.create_release.outputs.version }}_${{ needs.build_deb.outputs.architecture }}.deb | awk '{print $1}')" > ${{ github.workspace }}/${{ env.PACKAGE_NAME }}_${{ needs.create_release.outputs.version }}_${{ needs.build_deb.outputs.architecture }}.deb.sha256
 
       - name: Upload release asset
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
修正了生成的sha256校验和文件名中的架构变量引用错误，确保其使用构建步骤中正确的架构值。这一步骤对于保持发布资产的一致性和准确性至关重要。