### PR TITLE
更新下载 artifact 的名称

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -649,7 +649,7 @@ jobs:
       - name: Download ubuntu artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.OUTPUT_UBUNTU_NAME }}
+          name: ${{ env.PACKAGE_FILE_NAME_DEB }}
           path: ${{ github.workspace }}
 
       - name: List directory


### PR DESCRIPTION
将下载的 artifact 名称从 `OUTPUT_UBUNTU_NAME` 更改为 `PACKAGE_FILE_NAME_DEB`，以确保使用正确的文件名。