### PR TITLE
更新工作流以安装gpg并导入私钥

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -642,6 +642,17 @@ jobs:
       - build_deb
 
     steps:
+      - name: Install gpg and dput
+        run: |
+          sudo apt update -y
+          sudo apt install -y gpg
+          sudp apt install -y dput
+
+      - name: Import GPG private key
+        run: |
+          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --yes --import
+          gpg --list-keys
+
       - name: Download ubuntu artifact
         uses: actions/download-artifact@v4
         with:
@@ -650,11 +661,6 @@ jobs:
 
       - name: List directory
         run: ls -al ${{ github.workspace }}
-
-      - name: Install dput
-        run: |
-          sudo apt update -y
-          sudo apt install -y dput
 
       - name: Publish to ppa
         run: |


### PR DESCRIPTION
在工作流中添加了安装gpg和dput的步骤，并导入GPG私钥，以便后续步骤能够顺利执行。同时移除了重复的dput安装步骤。