### PR TITLE
更新 GPG 验证命令

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -663,7 +663,7 @@ jobs:
         run: ls -al ${{ github.workspace }}
 
       - name: Verify changes gpg
-        run: gpg --verify --batch --yes ${{ github.workspace }}/huan-go-test_1.109.0_amd64.changes
+        run: gpg --verify --batch --yes ${{ github.workspace }}/${{ env.PACKAGE_NAME }}_${{ needs.create_release.outputs.version }}_${{ needs.build_deb.outputs.architecture }}.changes
 
       - name: Publish to ppa
         run: |


### PR DESCRIPTION
将 GPG 验证命令中的硬编码文件名改为使用环境变量和工作流输出，以提高灵活性和复用性。这样可以确保在不同版本和架构下都能正确验证文件。