### PR TITLE
更新工作流以优化版本发布流程

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -52,7 +52,8 @@ jobs:
       volumes:
         - /home/runner/work:/home/runner/work
         - /home/runner/work:/__w
-    needs: ready
+    needs:
+      - ready
 
     steps:
       - name: Checkout code
@@ -84,7 +85,8 @@ jobs:
       volumes:
         - /home/runner/work:/home/runner/work
         - /home/runner/work:/__w
-    needs: ready
+    needs:
+      - ready
 
     steps:
       - name: Checkout code
@@ -108,13 +110,10 @@ jobs:
           path: ${{ github.workspace }}/${{ env.OUTPUT_REHL_NAME }}
           if-no-files-found: error
 
-  create_release:
+  get_version:
     runs-on: ubuntu-latest
     needs:
-      - build-ubuntu
-      - build-redhat
-
-    permissions: write-all
+      - ready
 
     steps:
       - name: Checkout code
@@ -126,12 +125,12 @@ jobs:
       - name: Fetch all tags
         run: git fetch --tags
 
-      - name: Create tag
-        id: tag_version
+      - name: Get new tag and version
+        id: get_tag_version
         run: |
           if [ -f ${{ github.workspace }}/${{ env.VERSION_FILE }} ]; then
             echo "VERSION file found."
-          
+
             if git tag --list | grep -q "^$(cat ${{ env.VERSION_FILE }})$"; then
               if [[ -n $(git tag --sort=-creatordate | grep -i '^v'  | head -1) ]]; then
                 tag=$(git tag --sort=-creatordate | grep -i '^v'  | head -1 | awk -F. '{print $1"."$2+1".0"}')
@@ -150,7 +149,7 @@ jobs:
             fi
           else
             echo "VERSION file not found."
-          
+
             if [[ -n $(git tag --sort=-creatordate | grep -i '^v'  | head -1) ]]; then
               tag=$(git tag --sort=-creatordate | grep -i '^v'  | head -1 | awk -F. '{print $1"."$2+1".0"}')
               echo "tag=$tag" >> $GITHUB_OUTPUT
@@ -163,116 +162,15 @@ jobs:
             fi
           fi
 
-      - name: Create Git tag
-        run: git tag "${{ steps.tag_version.outputs.tag }}"
-
-      - name: Download ubuntu artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ env.OUTPUT_UBUNTU_NAME }}
-          path: ${{ github.workspace }}
-
-      - name: Download redhat artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ env.OUTPUT_REHL_NAME }}
-          path: ${{ github.workspace }}
-
-      - name: List directory
-        run: ls -l ${{ github.workspace }}
-
-      - name: Push tag to github
-        run: git push origin "${{ steps.tag_version.outputs.tag }}"
-
-      - name: Write gpg public key
-        run: |
-          echo "${{ secrets.GPG_PUBLIC_KEY }}" > ${{ github.workspace }}/gpg_public_key.asc
-
-      - name: Write gpg key id
-        run: |
-          echo "${{ secrets.GPG_KEY_ID }}" > ${{ github.workspace }}/${{ secrets.GPG_KEY_ID }}.gpg.key.id
-
-      - name: Make release body
-        run: |
-          touch ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-          
-          echo '## 新版本 ${{ steps.tag_version.outputs.tag }} 正式发布 🚀🚀🚀' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-          echo '' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-          echo '欢迎大家前来体验使用！' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-          echo '' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-
-            echo '### GPG说明' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-            echo '' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-
-              echo '#### Linux上' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-              echo '' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-              echo '你可以通过 `GPG Key ID` 下载/安装我们的 `GPG` 证书，然后通过证书验证我们的文件！' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-              echo '我们的 `GPG Key ID: ${{ secrets.GPG_KEY_ID }}` 。' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-              echo '' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-
-                echo '##### 下载 GPG 证书' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-                echo '' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-                echo '你可以通过命令 `GPG` 进行操作，例如：`gpg --keyserver keyserver.ubuntu.com --recv-keys ${{ secrets.GPG_KEY_ID }}`' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-                echo '其中 `keyserver.ubuntu.com` 是 `GPG` 公开服务器，你也可以换用别的。' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-
-                echo '##### 安装 GPG 证书' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-                echo '' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-                echo '你只需要下载我们提供的 `gpg_public_key.asc` 然后执行，`gpg --import gpg_public_key.asc`' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-
-                echo '##### 验证文件' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-                echo '由 `GPG` 生成的分离式签名由 `.sig` 结尾，可以通过 `gpg --verify xxx.sig xxx` 进行验证，其中 `xxx` 为需要验证的文件。' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-                echo '' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-                echo '由 `sha256sum` 计算的校验码以 `.sha256` 结尾。' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-                echo '' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-                echo '对于 `deb` 系列的打包文件，可以下载 `changes` 文件（该文件是gpg签名，但非分离式），然后执行 `gpg --verify xxx.changes` 即可验证真伪，同时打开 `changes` 文件便可查看其他文件（例如: .deb）的 `sha256` 编码，从而对他们进行认证。' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-
-              echo '#### Windows/MacOS上' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-              echo '' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-              echo '大部分操作的原来和Linux是相同的。`GPG` 方面的操作可以借助 `Kleopatra`。' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-
-            echo '### 版本说明 [#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-            echo '' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-            echo '${{ github.event.pull_request.body }}' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-
-          echo '## 最后' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-          echo '' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-          echo '感谢大家！' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-          echo "$(date -u +"%Y-%m-%d %H:%M:%S UTC")" >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-          echo "$(TZ='Asia/Shanghai' date +"%Y-%m-%d %H:%M:%S Asia/Shanghai")" >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-          echo '' >> ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-
-      - name: Create github release
-        id: create_release
-        uses: softprops/action-gh-release@v2
-        with:
-          name: "👍 新版本 ${{ steps.tag_version.outputs.tag }} 发布啦 🚀🚀🚀"
-          tag_name: "${{ steps.tag_version.outputs.tag }}"
-          body_path: ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-          files: |
-            ${{ github.workspace }}/release_${{ steps.tag_version.outputs.tag }}_info.md
-            ${{ github.workspace }}/gpg_public_key.asc
-            ${{ github.workspace }}/${{ secrets.GPG_KEY_ID }}.gpg.key.id
-            ${{ github.workspace }}/${{ env.OUTPUT_UBUNTU_NAME }}
-            ${{ github.workspace }}/${{ env.OUTPUT_REHL_NAME }}
-          preserve_order: true
-          fail_on_unmatched_files: true
-          generate_release_notes: true
-          make_latest: "legacy"
-
-      - name: Output the URL of the new release
-        run: echo "The release is available at ${{ steps.create_release.outputs.html_url }}"
-
     outputs:
-      tag: "${{ steps.tag_version.outputs.tag }}"
-      version: "${{ steps.tag_version.outputs.version }}"
-      release: "${{ steps.create_release.outputs.url }}"
-      upload_url: "${{ steps.create_release.outputs.upload_url }}"
+      tag: "${{ steps.get_tag_version.outputs.tag }}"
+      version: "${{ steps.get_tag_version.outputs.version }}"
 
   build_deb:
     runs-on: ubuntu-latest
     needs:
       - ready
-      - create_release
+      - get_version
 
     env:
       FILE_SECTION: ".section"
@@ -302,6 +200,7 @@ jobs:
           sudo apt install -y debhelper
           sudo apt install -y fakeroot
           sudo apt install -y gnupg
+          sudo apt install -y git-buildpackage
 
       - name: Create and use a temporary directory
         id: create_temp
@@ -417,7 +316,7 @@ jobs:
           mkdir -p "${{ github.workspace }}/debian"
           mkdir -p "${{ github.workspace }}/bin"
           
-          VERSION="$(echo "${{ needs.create_release.outputs.tag }}" | sed 's/^v//')"
+          VERSION="$(echo "${{ needs.get_version.outputs.tag }}" | sed 's/^v//')"
           
           echo "Source: ${{ env.PACKAGE_NAME }}" > ${{ github.workspace }}/debian/control
           echo "Maintainer: $(cat ${{ github.workspace }}/${{ env.FILE_MAINTAINER }})" >> ${{ github.workspace }}/debian/control
@@ -451,6 +350,8 @@ jobs:
           
           if [ ! -f "${{ github.workspace }}/debian/changelog" ]; then
             EDITOR="/bin/true" VISUAL="/bin/true" DEBFULLNAME="$(git show -s --format='%an' $(git rev-list --max-parents=0 HEAD))" DEBEMAIL="$(git show -s --format='%ae' $(git rev-list --max-parents=0 HEAD))" dch --create --package ${{ env.PACKAGE_NAME }} --newversion 1.0.0 --force-distribution --distribution unstable "Initial release"
+          else
+            EDITOR="/bin/true" VISUAL="/bin/true" DEBFULLNAME="$(git show -s --format='%an' $(git rev-list --max-parents=0 HEAD))" DEBEMAIL="$(git show -s --format='%ae' $(git rev-list --max-parents=0 HEAD))" dch --package ${{ env.PACKAGE_NAME }} --auto --git-author --release --newversion ${VERSION} --force-distribution --distribution unstable
           fi 
           
           sudo chmod a+x "${{ github.workspace }}/${{ env.OUTPUT_UBUNTU_NAME }}"
@@ -458,8 +359,6 @@ jobs:
           
           echo "bin/${{ env.PACKAGE_NAME }} $(cat ${{ env.FILE_BIN_PATH }})" > ${{ github.workspace }}/debian/${{ env.PACKAGE_NAME }}.install
           
-          EDITOR="/bin/true" VISUAL="/bin/true" DEBFULLNAME="$(git show -s --format='%an' $(git rev-list --max-parents=0 HEAD))" DEBEMAIL="$(git show -s --format='%ae' $(git rev-list --max-parents=0 HEAD))" dch --package ${{ env.PACKAGE_NAME }} --newversion ${VERSION} --force-distribution --distribution unstable "Visit to ${{ needs.create_release.outputs.release }}!"
-
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "architecture=$(cat ${{ github.workspace }}/${{ env.FILE_ARCHITECTURE }})" >> $GITHUB_OUTPUT
           echo "maintainer=$(cat ${{ github.workspace }}/${{ env.FILE_MAINTAINER }})" >> $GITHUB_OUTPUT
@@ -485,6 +384,12 @@ jobs:
           gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback --detach-sign ./${{ env.PACKAGE_NAME }}_${{ steps.before-package.outputs.version }}_${{ steps.before-package.outputs.architecture }}.deb
           cd -
 
+      - name: Get sha256
+        runs: |
+          cd ${{ github.workspace }}/..
+          echo "$(sha256sum ./${{ env.PACKAGE_NAME }}_${{ needs.get_version.outputs.version }}_${{ needs.build_deb.outputs.architecture }}.deb | awk '{print $1}')" > ./${{ env.PACKAGE_NAME }}_${{ needs.get_version.outputs.version }}_${{ needs.build_deb.outputs.architecture }}.deb.sha256
+          cd -
+
       - name: List directory after package
         run: ls -al ${{ github.workspace }}/../
 
@@ -494,6 +399,7 @@ jobs:
           cp ${{ github.workspace }}/../${{ env.PACKAGE_NAME }}_${{ steps.before-package.outputs.version }}.tar.gz ${{ steps.create_temp.outputs.temp }}
           cp ${{ github.workspace }}/../${{ env.PACKAGE_NAME }}_${{ steps.before-package.outputs.version }}_${{ steps.before-package.outputs.architecture }}.deb ${{ steps.create_temp.outputs.temp }}
           cp ${{ github.workspace }}/../${{ env.PACKAGE_NAME }}_${{ steps.before-package.outputs.version }}_${{ steps.before-package.outputs.architecture }}.deb.sig ${{ steps.create_temp.outputs.temp }}
+          cp ${{ github.workspace }}/../${{ env.PACKAGE_NAME }}_${{ steps.before-package.outputs.version }}_${{ steps.before-package.outputs.architecture }}.deb.sha256 ${{ steps.create_temp.outputs.temp }}
           cp ${{ github.workspace }}/../${{ env.PACKAGE_NAME }}_${{ steps.before-package.outputs.version }}_${{ steps.before-package.outputs.architecture }}.buildinfo ${{ steps.create_temp.outputs.temp }}
           cp ${{ github.workspace }}/../${{ env.PACKAGE_NAME }}_${{ steps.before-package.outputs.version }}_${{ steps.before-package.outputs.architecture }}.changes ${{ steps.create_temp.outputs.temp }}
 
@@ -506,6 +412,7 @@ jobs:
             ${{ steps.create_temp.outputs.temp }}/${{ env.PACKAGE_NAME }}_${{ steps.before-package.outputs.version }}.tar.gz
             ${{ steps.create_temp.outputs.temp }}/${{ env.PACKAGE_NAME }}_${{ steps.before-package.outputs.version }}_${{ steps.before-package.outputs.architecture }}.deb
             ${{ steps.create_temp.outputs.temp }}/${{ env.PACKAGE_NAME }}_${{ steps.before-package.outputs.version }}_${{ steps.before-package.outputs.architecture }}.deb.sig
+            ${{ steps.create_temp.outputs.temp }}/${{ env.PACKAGE_NAME }}_${{ steps.before-package.outputs.version }}_${{ steps.before-package.outputs.architecture }}.deb.sha256
             ${{ steps.create_temp.outputs.temp }}/${{ env.PACKAGE_NAME }}_${{ steps.before-package.outputs.version }}_${{ steps.before-package.outputs.architecture }}.buildinfo
             ${{ steps.create_temp.outputs.temp }}/${{ env.PACKAGE_NAME }}_${{ steps.before-package.outputs.version }}_${{ steps.before-package.outputs.architecture }}.changes
           if-no-files-found: error
@@ -541,7 +448,7 @@ jobs:
       - name: Push debian/changelog
         run: |
           git add ${{ github.workspace }}/debian/changelog
-          EDITOR="/bin/true" VISUAL="/bin/true" git commit -m "Update debian/changelog for ${{needs.create_release.outputs.tag}}"
+          EDITOR="/bin/true" VISUAL="/bin/true" git commit -m "Update debian/changelog for ${{needs.get_version.outputs.tag}}"
           git push -f origin HEAD:${{ env.CHANGE_LOG_DEB_BRANCH }}
 
       - name: Create or get pull request
@@ -586,38 +493,127 @@ jobs:
   publish_deb_to_release:
     runs-on: ubuntu-latest
     needs:
-      - create_release
+      - get_version
       - build_deb
 
+    permissions: write-all
+
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for all branches and tags
+          fetch-tags: true
+
+      - name: Download ubuntu artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.OUTPUT_UBUNTU_NAME }}
+          path: ${{ github.workspace }}
+
+      - name: Download redhat artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.OUTPUT_REHL_NAME }}
+          path: ${{ github.workspace }}
+
       - name: Download package dev artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.PACKAGE_FILE_NAME_DEB }}
           path: ${{ github.workspace }}
 
-      - name: Get file sha256
+      - name: Write gpg public key
         run: |
-          echo "$(sha256sum ${{ github.workspace }}/${{ env.PACKAGE_NAME }}_${{ needs.create_release.outputs.version }}_${{ needs.build_deb.outputs.architecture }}.deb | awk '{print $1}')" > ${{ github.workspace }}/${{ env.PACKAGE_NAME }}_${{ needs.create_release.outputs.version }}_${{ needs.build_deb.outputs.architecture }}.deb.sha256
+          echo "${{ secrets.GPG_PUBLIC_KEY }}" > ${{ github.workspace }}/gpg_public_key.asc
 
-      - name: Upload release asset
+      - name: Write gpg key id
+        run: |
+          echo "${{ secrets.GPG_KEY_ID }}" > ${{ github.workspace }}/${{ secrets.GPG_KEY_ID }}.gpg.key.id
+
+      - name: List directory
+        run: ls -l ${{ github.workspace }}
+
+      - name: Make release body
+        run: |
+          touch ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+          
+          echo '## 新版本 ${{ steps.create_temp.outputs.temp }} 正式发布 🚀🚀🚀' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+          echo '' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+          echo '欢迎大家前来体验使用！' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+          echo '' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+
+            echo '### GPG说明' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+            echo '' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+
+              echo '#### Linux上' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+              echo '' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+              echo '你可以通过 `GPG Key ID` 下载/安装我们的 `GPG` 证书，然后通过证书验证我们的文件！' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+              echo '我们的 `GPG Key ID: ${{ secrets.GPG_KEY_ID }}` 。' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+              echo '' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+
+                echo '##### 下载 GPG 证书' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+                echo '' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+                echo '你可以通过命令 `GPG` 进行操作，例如：`gpg --keyserver keyserver.ubuntu.com --recv-keys ${{ secrets.GPG_KEY_ID }}`' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+                echo '其中 `keyserver.ubuntu.com` 是 `GPG` 公开服务器，你也可以换用别的。' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+
+                echo '##### 安装 GPG 证书' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+                echo '' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+                echo '你只需要下载我们提供的 `gpg_public_key.asc` 然后执行，`gpg --import gpg_public_key.asc`' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+
+                echo '##### 验证文件' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+                echo '由 `GPG` 生成的分离式签名由 `.sig` 结尾，可以通过 `gpg --verify xxx.sig xxx` 进行验证，其中 `xxx` 为需要验证的文件。' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+                echo '' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+                echo '由 `sha256sum` 计算的校验码以 `.sha256` 结尾。' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+                echo '' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+                echo '对于 `deb` 系列的打包文件，可以下载 `changes` 文件（该文件是gpg签名，但非分离式），然后执行 `gpg --verify xxx.changes` 即可验证真伪，同时打开 `changes` 文件便可查看其他文件（例如: .deb）的 `sha256` 编码，从而对他们进行认证。' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+
+              echo '#### Windows/MacOS上' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+              echo '' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+              echo '大部分操作的原来和Linux是相同的。`GPG` 方面的操作可以借助 `Kleopatra`。' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+
+            echo '### 版本说明 [#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+            echo '' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+            echo '${{ github.event.pull_request.body }}' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+
+          echo '## 最后' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+          echo '' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+          echo '感谢大家！' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+          echo "$(date -u +"%Y-%m-%d %H:%M:%S UTC")" >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+          echo "$(TZ='Asia/Shanghai' date +"%Y-%m-%d %H:%M:%S Asia/Shanghai")" >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+          echo '' >> ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+
+      - name: Push tag to github
+        run: |
+          git tag ${{ needs.get_version.outputs.tag }}
+          git push origin "${{ needs.get_version.outputs.tag }}"
+
+      - name: Create github release
+        id: create_release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.create_release.outputs.tag }}
+          name: "👍 新版本 ${{ steps.create_temp.outputs.temp }} 发布啦 🚀🚀🚀"
+          tag_name: "${{ steps.create_temp.outputs.temp }}"
+          body_path: ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
           files: |
-            ${{ github.workspace }}/${{ env.PACKAGE_NAME }}_${{ needs.create_release.outputs.version }}_${{ needs.build_deb.outputs.architecture }}.deb
-            ${{ github.workspace }}/${{ env.PACKAGE_NAME }}_${{ needs.create_release.outputs.version }}_${{ needs.build_deb.outputs.architecture }}.changes
-            ${{ github.workspace }}/${{ env.PACKAGE_NAME }}_${{ needs.create_release.outputs.version }}_${{ needs.build_deb.outputs.architecture }}.deb.sig
-            ${{ github.workspace }}/${{ env.PACKAGE_NAME }}_${{ needs.create_release.outputs.version }}_${{ needs.build_deb.outputs.architecture }}.deb.sha256
+            ${{ github.workspace }}/release_${{ steps.create_temp.outputs.temp }}_info.md
+            ${{ github.workspace }}/gpg_public_key.asc
+            ${{ github.workspace }}/${{ secrets.GPG_KEY_ID }}.gpg.key.id
+            ${{ github.workspace }}/${{ env.OUTPUT_UBUNTU_NAME }}
+            ${{ github.workspace }}/${{ env.OUTPUT_REHL_NAME }}
+            ${{ github.workspace }}/${{ env.PACKAGE_NAME }}_${{ needs.get_version.outputs.version }}_${{ needs.build_deb.outputs.architecture }}.deb
+            ${{ github.workspace }}/${{ env.PACKAGE_NAME }}_${{ needs.get_version.outputs.version }}_${{ needs.build_deb.outputs.architecture }}.changes
+            ${{ github.workspace }}/${{ env.PACKAGE_NAME }}_${{ needs.get_version.outputs.version }}_${{ needs.build_deb.outputs.architecture }}.deb.sig
+            ${{ github.workspace }}/${{ env.PACKAGE_NAME }}_${{ needs.get_version.outputs.version }}_${{ needs.build_deb.outputs.architecture }}.deb.sha256
           preserve_order: true
           fail_on_unmatched_files: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # 自动提供的 GitHub Token
+          generate_release_notes: true
+          make_latest: "legacy"
 
   publish_deb_to_ppa:
     runs-on: ubuntu-latest
     needs:
-      - create_release
+      - get_version
       - build_deb
 
     steps:
@@ -648,9 +644,9 @@ jobs:
         run: ls -al ${{ github.workspace }}
 
       - name: Verify changes gpg
-        run: gpg --verify --batch --yes ${{ github.workspace }}/${{ env.PACKAGE_NAME }}_${{ needs.create_release.outputs.version }}_${{ needs.build_deb.outputs.architecture }}.changes
+        run: gpg --verify --batch --yes ${{ github.workspace }}/${{ env.PACKAGE_NAME }}_${{ needs.get_version.outputs.version }}_${{ needs.build_deb.outputs.architecture }}.changes
 
       - name: Publish to ppa
         run: |
           echo "PPA Address: ${{ vars.PPA_NAME }}"
-          dput ppa:${{ vars.PPA_NAME }} ${{ github.workspace }}/${{ env.PACKAGE_NAME }}_${{ needs.create_release.outputs.version }}_${{ needs.build_deb.outputs.architecture }}.changes
+          dput ppa:${{ vars.PPA_NAME }} ${{ github.workspace }}/${{ env.PACKAGE_NAME }}_${{ needs.get_version.outputs.version }}_${{ needs.build_deb.outputs.architecture }}.changes


### PR DESCRIPTION
将 `create_release` 任务拆分为 `get_version` 和 `publish_deb_to_release`，并调整相关依赖关系。同时，增加了生成 `.sha256` 文件的步骤，并在 `publish_deb_to_release` 中包含了更多的文件上传。