### PR TITLE
更新 `gbp dch` 命令参数

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -351,7 +351,7 @@ jobs:
           if [ ! -f "${{ github.workspace }}/debian/changelog" ]; then
             EDITOR="/bin/true" VISUAL="/bin/true" DEBFULLNAME="$(git show -s --format='%an' $(git rev-list --max-parents=0 HEAD))" DEBEMAIL="$(git show -s --format='%ae' $(git rev-list --max-parents=0 HEAD))" dch --create --package ${{ env.PACKAGE_NAME }} --newversion 0.1.0 "Initial release"
           else
-            EDITOR="/bin/true" VISUAL="/bin/true" DEBFULLNAME="$(git show -s --format='%an' $(git rev-list --max-parents=0 HEAD))" DEBEMAIL="$(git show -s --format='%ae' $(git rev-list --max-parents=0 HEAD))" gbp dch --package ${{ env.PACKAGE_NAME }} --auto --git-author --release --newversion ${VERSION}
+            EDITOR="/bin/true" VISUAL="/bin/true" DEBFULLNAME="$(git show -s --format='%an' $(git rev-list --max-parents=0 HEAD))" DEBEMAIL="$(git show -s --format='%ae' $(git rev-list --max-parents=0 HEAD))" gbp dch --auto --git-author --release --newversion ${VERSION}
           fi 
           
           sudo chmod a+x "${{ github.workspace }}/${{ env.OUTPUT_UBUNTU_NAME }}"


### PR DESCRIPTION
移除了 `--package ${{ env.PACKAGE_NAME }}` 参数，简化了 `gbp dch` 命令的调用。这将使 changelog 的生成更加简洁。