### PR TITLE
更新 `gbp dch` 命令以忽略分支

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -351,7 +351,7 @@ jobs:
           if [ ! -f "${{ github.workspace }}/debian/changelog" ]; then
             EDITOR="/bin/true" VISUAL="/bin/true" DEBFULLNAME="$(git show -s --format='%an' $(git rev-list --max-parents=0 HEAD))" DEBEMAIL="$(git show -s --format='%ae' $(git rev-list --max-parents=0 HEAD))" dch --create --package ${{ env.PACKAGE_NAME }} --newversion 0.1.0 "Initial release"
           else
-            EDITOR="/bin/true" VISUAL="/bin/true" DEBFULLNAME="$(git show -s --format='%an' $(git rev-list --max-parents=0 HEAD))" DEBEMAIL="$(git show -s --format='%ae' $(git rev-list --max-parents=0 HEAD))" gbp dch --auto --git-author --release --new-version ${VERSION}
+            EDITOR="/bin/true" VISUAL="/bin/true" DEBFULLNAME="$(git show -s --format='%an' $(git rev-list --max-parents=0 HEAD))" DEBEMAIL="$(git show -s --format='%ae' $(git rev-list --max-parents=0 HEAD))" gbp dch --auto --git-author --release --ignore-branch --new-version ${VERSION}
           fi 
           
           sudo chmod a+x "${{ github.workspace }}/${{ env.OUTPUT_UBUNTU_NAME }}"


### PR DESCRIPTION
在 `go-pr-merge.yml` 工作流中，修改了 `gbp dch` 命令，添加了 `--ignore-branch` 选项，以便在生成变更日志时忽略当前分支。这样可以确保版本号的自动生成更加灵活。