### PR TITLE
修复SHA256文件命名不一致问题

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -384,7 +384,7 @@ jobs:
       - name: Get sha256
         run: |
           cd ${{ github.workspace }}/..
-          echo "$(sha256sum ./${{ env.PACKAGE_NAME }}_${{ needs.get-tag-version.outputs.version }}_${{ steps.before_package.outputs.architecture }}.deb | awk '{print $1}')" > ./${{ env.PACKAGE_NAME }}_${{ needs.get-tag-version.outputs.version }}_${{ needs.build-ubuntu.outputs.architecture }}.deb.sha256
+          echo "$(sha256sum ./${{ env.PACKAGE_NAME }}_${{ needs.get-tag-version.outputs.version }}_${{ steps.before_package.outputs.architecture }}.deb | awk '{print $1}')" > ./${{ env.PACKAGE_NAME }}_${{ needs.get-tag-version.outputs.version }}_${{ steps.before_package.outputs.architecture }}.deb.sha256
           cd -
 
       - name: List directory after package


### PR DESCRIPTION
修正了生成SHA256校验和文件时的命名不一致问题，确保文件名中的架构信息与之前步骤中的一致。这样可以避免后续步骤中因文件名错误导致的问题。