### PR TITLE
移除不必要的文件复制和打包步骤

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -392,7 +392,6 @@ jobs:
 
       - name: Temporary copy file
         run: |
-          cp ${{ github.workspace }}/../${{ env.PACKAGE_NAME }}_${{ needs.get-tag-version.outputs.version }}.tar.gz ${{ steps.create_temp.outputs.temp }}
           cp ${{ github.workspace }}/../${{ env.PACKAGE_NAME }}_${{ needs.get-tag-version.outputs.version }}_${{ steps.before_package.outputs.architecture }}.deb ${{ steps.create_temp.outputs.temp }}
           cp ${{ github.workspace }}/../${{ env.PACKAGE_NAME }}_${{ needs.get-tag-version.outputs.version }}_${{ steps.before_package.outputs.architecture }}.deb.sig ${{ steps.create_temp.outputs.temp }}
           cp ${{ github.workspace }}/../${{ env.PACKAGE_NAME }}_${{ needs.get-tag-version.outputs.version }}_${{ steps.before_package.outputs.architecture }}.deb.sha256 ${{ steps.create_temp.outputs.temp }}
@@ -404,7 +403,6 @@ jobs:
         with:
           name: ${{ env.PACKAGE_FILE_NAME_DEB }}
           path: |
-            ${{ steps.create_temp.outputs.temp }}/${{ env.PACKAGE_NAME }}_${{ needs.get-tag-version.outputs.version }}.tar.gz
             ${{ steps.create_temp.outputs.temp }}/${{ env.PACKAGE_NAME }}_${{ needs.get-tag-version.outputs.version }}_${{ steps.before_package.outputs.architecture }}.deb
             ${{ steps.create_temp.outputs.temp }}/${{ env.PACKAGE_NAME }}_${{ needs.get-tag-version.outputs.version }}_${{ steps.before_package.outputs.architecture }}.deb.sig
             ${{ steps.create_temp.outputs.temp }}/${{ env.PACKAGE_NAME }}_${{ needs.get-tag-version.outputs.version }}_${{ steps.before_package.outputs.architecture }}.deb.sha256


### PR DESCRIPTION
在 GitHub Actions 工作流中，移除了对 `.tar.gz` 文件的复制和打包操作，仅保留了对 `.deb` 及其相关文件的操作。这样可以简化流程并减少冗余。