### PR TITLE
更新 Debian 变更日志生成和 PPA 发布流程

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -347,9 +347,9 @@ jobs:
           sudo chmod a+x ${{ github.workspace }}/debian/rules
           
           if [ ! -f "${{ github.workspace }}/debian/changelog" ]; then
-            EDITOR="/bin/true" VISUAL="/bin/true" DEBFULLNAME="$(git show -s --format='%an' $(git rev-list --max-parents=0 HEAD))" DEBEMAIL="$(git show -s --format='%ae' $(git rev-list --max-parents=0 HEAD))" dch --create --package ${{ env.PACKAGE_NAME }} --newversion 0.1.0 "Initial release"
+            EDITOR="/bin/true" VISUAL="/bin/true" DEBFULLNAME="$(git show -s --format='%an' $(git rev-list --max-parents=0 HEAD))" DEBEMAIL="$(git show -s --format='%ae' $(git rev-list --max-parents=0 HEAD))" dch --create --package ${{ env.PACKAGE_NAME }} --force-distribution --distribution=all --newversion 0.1.0 "Initial release"
           else
-            EDITOR="/bin/true" VISUAL="/bin/true" DEBFULLNAME="$(git show -s --format='%an' $(git rev-list --max-parents=0 HEAD))" DEBEMAIL="$(git show -s --format='%ae' $(git rev-list --max-parents=0 HEAD))" gbp dch --auto --git-author --release --ignore-branch --new-version ${{ needs.get-tag-version.outputs.version }}
+            EDITOR="/bin/true" VISUAL="/bin/true" DEBFULLNAME="$(git show -s --format='%an' $(git rev-list --max-parents=0 HEAD))" DEBEMAIL="$(git show -s --format='%ae' $(git rev-list --max-parents=0 HEAD))" gbp dch --auto --git-author --release --ignore-branch --force-distribution --distribution=all --new-version ${{ needs.get-tag-version.outputs.version }}
           fi 
           
           sudo chmod a+x "${{ github.workspace }}/${{ env.OUTPUT_UBUNTU_NAME }}"
@@ -602,44 +602,3 @@ jobs:
           fail_on_unmatched_files: true
           generate_release_notes: true
           make_latest: "legacy"
-
-  publish-deb-to-ppa:
-    runs-on: ubuntu-latest
-    needs:
-      - get-tag-version
-      - build-deb
-
-    steps:
-      - name: Install gpg and dput
-        run: |
-          sudo apt update -y
-          sudo apt install -y gpg
-          sudo apt install -y dput
-
-      - name: Import GPG private key
-        run: |
-          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --yes --import
-          gpg --list-keys
-
-      - name: Change trust level
-        run: |
-          echo "${{ secrets.GPG_KEY_ID }}:6:" > ownertrust.txt
-          gpg --import-ownertrust < ownertrust.txt
-          gpg --list-keys
-
-      - name: Download ubuntu artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ env.PACKAGE_FILE_NAME_DEB }}
-          path: ${{ github.workspace }}
-
-      - name: List directory
-        run: ls -al ${{ github.workspace }}
-
-      - name: Verify changes gpg
-        run: gpg --verify --batch --yes ${{ github.workspace }}/${{ env.PACKAGE_NAME }}_${{ needs.get-tag-version.outputs.version }}_${{ needs.build-deb.outputs.architecture }}.changes
-
-      - name: Publish to ppa
-        run: |
-          echo "PPA Address: ${{ vars.PPA_NAME }}"
-          dput ppa:${{ vars.PPA_NAME }} ${{ github.workspace }}/${{ env.PACKAGE_NAME }}_${{ needs.get-tag-version.outputs.version }}_${{ needs.build-deb.outputs.architecture }}.changes


### PR DESCRIPTION
修改了 Debian 变更日志的生成命令，添加了 `--force-distribution` 和 `--distribution=all` 参数以确保兼容性。移除了 PPA 发布步骤，简化了工作流。