### PR TITLE
更新工作流以依赖ready任务

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -520,15 +520,13 @@ jobs:
   publish-deb-to-release:
     runs-on: ubuntu-latest
     needs:
+      - ready
       - build-deb
     permissions: write-all
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Fetch all history for all branches and tags
-          fetch-tags: true
 
       - name: Download ubuntu artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
在publish-deb-to-release任务中添加了对ready任务的依赖，并移除了代码检出时获取全部历史和标签的配置。