### PR TITLE
修复拼写错误

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -129,7 +129,7 @@ jobs:
           fi
           
       - name: tmp-step
-        rum: |
+        run: |
           echo "tag is ${{ steps.get_tag_version.outputs.tag }}"
           echo "version is ${{ steps.get_tag_version.outputs.version }}"
 


### PR DESCRIPTION
修正了 `tmp-step` 中的拼写错误，将 `rum` 改为 `run`，以确保步骤能够正确执行。