### PR TITLE
修正版本号提取逻辑

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -104,7 +104,7 @@ jobs:
               fi
             else
               echo "tag=$(cat ${{ env.VERSION_FILE }})" >> $GITHUB_OUTPUT
-              echo "version=$(echo ${{ env.VERSION_FILE }} | sed 's/^v//')" >> $GITHUB_OUTPUT
+              echo "version=$(cat ${{ env.VERSION_FILE }} | sed 's/^v//')" >> $GITHUB_OUTPUT
               echo "File Version is $(cat ${{ env.VERSION_FILE }})"
             fi
           else


### PR DESCRIPTION
将版本号提取命令从直接读取环境变量改为读取文件内容，确保正确获取版本信息。这样可以避免因环境变量未正确设置而导致的版本号错误。