### PR TITLE
检查并更新版本标签逻辑

### DIFF
--- a/.github/workflows/go-pr-merge.yml
+++ b/.github/workflows/go-pr-merge.yml
@@ -113,20 +113,21 @@ jobs:
           else
             echo "VERSION file not found."
       
-                latest_tag = $(git tag --sort=-creatordate | grep -i '^v'  | head -1)
-                lastest_version = "${latest_tag#v}"
-          
-                if [[ ${{ steps.check_label.outputs.BUG_PR }} == "true" ]]; then
-                  tag=$(echo $lastest_version | awk -F. '{print $1"."$2"."$3+1}')
-                elif [[ ${{ steps.check_label.outputs.FEATURE_PR }} == "true" ]]; then
-                  tag=$(echo $lastest_version | awk -F. '{print $1+1".0.0"}')
-                else
-                  tag=$(echo $lastest_version | awk -F. '{print $1"."$2+1".0"}')
-                fi
-          
-                echo "tag=v$latest_tag" >> $GITHUB_OUTPUT
-                echo "version=$lastest_version" >> $GITHUB_OUTPUT
-                echo "Auto Version is $lastest_version"
+            if [[ -n $(git tag --sort=-creatordate | grep -i '^v'  | head -1) ]]; then
+              latest_tag = $(git tag --sort=-creatordate | grep -i '^v'  | head -1)
+              lastest_version = "${latest_tag#v}"
+        
+              if [[ ${{ steps.check_label.outputs.BUG_PR }} == "true" ]]; then
+                tag=$(echo $lastest_version | awk -F. '{print $1"."$2"."$3+1}')
+              elif [[ ${{ steps.check_label.outputs.FEATURE_PR }} == "true" ]]; then
+                tag=$(echo $lastest_version | awk -F. '{print $1+1".0.0"}')
+              else
+                tag=$(echo $lastest_version | awk -F. '{print $1"."$2+1".0"}')
+              fi
+        
+              echo "tag=v$latest_tag" >> $GITHUB_OUTPUT
+              echo "version=$lastest_version" >> $GITHUB_OUTPUT
+              echo "Auto Version is $lastest_version"
             else
               echo "tag=v0.1.0" >> $GITHUB_OUTPUT
               echo "version=0.1.0" >> $GITHUB_OUTPUT
@@ -134,10 +135,11 @@ jobs:
             fi
           fi
           
-      - name: tmp-step
+      - name: Show info
         run: |
-          echo "tag is ${{ steps.get_tag_version.outputs.tag }}"
-          echo "version is ${{ steps.get_tag_version.outputs.version }}"
+          echo "Default branch is ${{ steps.get_branch.outputs.branch }}"
+          echo "Tag is ${{ steps.get_tag_version.outputs.tag }}"
+          echo "Version is ${{ steps.get_tag_version.outputs.version }}"
 
     outputs:
       branch: ${{ steps.get_branch.outputs.branch }}


### PR DESCRIPTION
在获取最新标签前添加了检查，确保只有存在标签时才进行版本更新操作。同时，在输出信息步骤中增加了默认分支的显示。